### PR TITLE
Documentation/60 build how to compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ dkms.conf
 
 # Build specific
 build
+build-with-coverage
 Testing
 myteams_server
 myteams_cli

--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # mes_equipes
-MicroDoux Equipes clone
+[![Build](https://github.com/Cavonstavant/mes_equipes/actions/workflows/cmake.yml/badge.svg)](https://github.com/Cavonstavant/mes_equipes/actions/workflows/cmake.yml) [![GH Pages deployment](https://github.com/Cavonstavant/mes_equipes/actions/workflows/doc_build.yml/badge.svg)](https://github.com/Cavonstavant/mes_equipes/actions/workflows/doc_build.yml) [![Mirroring](https://github.com/Cavonstavant/mes_equipes/actions/workflows/mirroring.yml/badge.svg)](https://github.com/Cavonstavant/mes_equipes/actions/workflows/mirroring.yml) [![forthebadge](https://forthebadge.com/images/badges/works-on-my-machine.svg)](https://forthebadge.com)
+> MicroDoux Equipes clone
+
+## Documentation
+
+The documentation is currently hosted [here](https://cavonstavant.github.io/mes_equipes/index.html).
+
+> Local documentation cna be generated using doxygen with running `doxygen` at the root of the repository. Use `xdg-open doc/build/html/index.html` to open it.
+
+## Build
+
+### Tools
+
+    - CMake >= 3.17.0
+    - C11
+
+### Building
+
+On Linux:
+
+```bash
+    git clone https://github.com/Cavonstavant/mes_equipes.git
+    cd mes_equipes/
+    cmake -B ./build -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release
+    cmake --build ./build
+```
+
+Building the tests:
+
+```bash
+    cmake -B ./build-with-coverage -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DENABLE_CODE_COVERAGE=ON
+    cmake --build ./build-with-coverage
+```
+
+Running the tests and get the coverage report:
+
+```bash
+    ./launch_tests.sh
+```

--- a/launch_tests.sh
+++ b/launch_tests.sh
@@ -1,0 +1,7 @@
+cmake -B ./build-with-coverage -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DENABLE_CODE_COVERAGE=ON
+cmake --build ./build-with-coverage -j 10
+ctest --test-dir ./build-with-coverage
+find ./build-with-coverage -name "*.gcda" -exec cp {} ./build-with-coverage/coverage-report \;
+find ./build-with-coverage -name "*.gcno" -exec cp {} ./build-with-coverage/coverage-report \;
+gcovr --exclude ../../tests
+gcovr --exclude ../../tests --branches

--- a/server/src/CMakeLists.txt
+++ b/server/src/CMakeLists.txt
@@ -12,11 +12,9 @@ add_executable(${TARGET} ${SRC})
 # target_include_directories(${TARGET}_core
 #     PUBLIC ${INCLUDE_DIRS}
 #     PRIVATE ${SRC_ROOT}
+#     PRIVATE ${TARGET_NAME}_commands
 # )
 
-target_link_libraries(${TARGET}
-    PRIVATE ${PROJECT_NAME}_commands
-)
 set_target_properties(${TARGET} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}
 )

--- a/server/src/commands/CMakeLists.txt
+++ b/server/src/commands/CMakeLists.txt
@@ -1,13 +1,13 @@
 set (INC_COMMANDS ${PROJECT_SOURCE_DIR}/server/src/commands)
 set (SRC_COMMANDS ${PROJECT_SOURCE_DIR}/server/src/commands)
 
-set (SRC)
-
 set (TARGET ${PROJECT_NAME}_commands)
 
-add_library(${TARGET} ${SRC})
+# set (SRC)
 
-target_include_directories(${TARGET}
-    PUBLIC ${INC_COMMANDS}
-    PRIVATE ${SRC_COMMANDS}
-)
+# add_library(${TARGET} ${SRC})
+
+# target_include_directories(${TARGET}
+#     PUBLIC ${INC_COMMANDS}
+#     PRIVATE ${SRC_COMMANDS}
+# )


### PR DESCRIPTION
This pull request:
- adds more documentation inside the README.md
- Creates a `launch_tests.sh` bash script to configure, build and launch tests & tests report
- Fix crashing `CMakeLists.txt` inside teams_commands

Fix #60
