### PR TITLE
Client command/73 rfc returns codes

### DIFF
--- a/server/src/commands/CMakeLists.txt
+++ b/server/src/commands/CMakeLists.txt
@@ -3,11 +3,13 @@ set (SRC_COMMANDS ${PROJECT_SOURCE_DIR}/server/src/commands)
 
 set (TARGET ${PROJECT_NAME}_commands)
 
-# set (SRC)
+set (SRC
+    ${INC_COMMANDS}/rcodes.h
+)
 
-# add_library(${TARGET} ${SRC})
+add_library(${TARGET} ${SRC})
 
-# target_include_directories(${TARGET}
-#     PUBLIC ${INC_COMMANDS}
-#     PRIVATE ${SRC_COMMANDS}
-# )
+target_include_directories(${TARGET}
+    PUBLIC ${INC_COMMANDS}
+    PRIVATE ${SRC_COMMANDS}
+)

--- a/server/src/commands/rcodes.h
+++ b/server/src/commands/rcodes.h
@@ -5,11 +5,16 @@
 ** rcodes
 */
 
+/// \file server/src/commands/rcodes.h
+
 #ifndef RCODES_H_
     #define RCODES_H_
 
     #include <stdlib.h>
 
+/// \brief The retcodes_s structure contains the representation of the return
+/// code as char *, an int which represent the return code, and a array of
+/// char * which contains the arguments to be used.
 typedef struct retcodes_s {
     char *repr;
     int code;

--- a/server/src/commands/rcodes.h
+++ b/server/src/commands/rcodes.h
@@ -21,34 +21,34 @@ typedef struct retcodes_s {
     char **params;
 } retcodes_t;
 
-const retcodes_t retcode[] = {
-    {.repr = "200 Success\n", .code = 200, .params = 0},
-    {.repr = "201 Successfully connected to existing used: %s\n", .code = 201, .params = 0},
-    {.repr = "202 Successfully connected, new user created with username: %s\n", .code = 202, .params = 0},
-    {.repr = "203 Successfully disconnected as user: %s\n", .code = 203, .params = 0},
-    {.repr = "310 No requested data found, empty relation\n", .code = 310, .params = 0},
-    {.repr = "311 Reqested UUID: %s not found\n", .code = 311, .params = 0},
-    {.repr = "312 Requested username: %s not found\n", .code = 312, .params = 0},
-    {.repr = "320 Invalid action: Data already exist\n", .code = 320, .params = 0},
-    {.repr = "321 Invalid action: Already subscribed to %s\n", .code = 321, .params = 0},
-    {.repr = "322 Invalid action: Not subscribed to %s\n", .code = 322, .params = 0},
-    {.repr = "401 Invalid requested action, please login\n", .code = 400, .params = 0},
-    {.repr = "500 Syntax error\n", .code = 500, .params = 0},
-    {.repr = "501 Format error: Invalid UUID\n", .code = 501, .params = 0},
-    {.repr = "502 Format error: body too long\n", .code = 502, .params = 0},
-    {.repr = "503 Format error: name too long\n", .code = 503, .params = 0},
-    {.repr = "504 Format error: description too long\n", .code = 504, .params = 0},
-    {.repr = "510 Syntax error: Wrong number of arguments\n", .code = 510, .params = 0},
-    {.repr = "520 Syntax error: Invalid format\n", .code = 520, .params = 0},
-    {.repr = "530 Syntax error: Command not found\n", .code = 530, .params = 0},
-    {.repr = "540 Syntax error: Not implemented\n", .code = 540, .params = 0},
+static const retcodes_t retcode[] = {
+    {.repr = "200 Success\n", .code = 200, .params = NULL},
+    {.repr = "201 Successfully connected to existing used: %s\n", .code = 201, .params = NULL},
+    {.repr = "202 Successfully connected, new user created with username: %s\n", .code = 202, .params = NULL},
+    {.repr = "203 Successfully disconnected as user: %s\n", .code = 203, .params = NULL},
+    {.repr = "310 No requested data found, empty relation\n", .code = 310, .params = NULL},
+    {.repr = "311 Reqested UUID: %s not found\n", .code = 311, .params = NULL},
+    {.repr = "312 Requested username: %s not found\n", .code = 312, .params = NULL},
+    {.repr = "320 Invalid action: Data already exist\n", .code = 320, .params = NULL},
+    {.repr = "321 Invalid action: Already subscribed to %s\n", .code = 321, .params = NULL},
+    {.repr = "322 Invalid action: Not subscribed to %s\n", .code = 322, .params = NULL},
+    {.repr = "401 Invalid requested action, please login\n", .code = 400, .params = NULL},
+    {.repr = "500 Syntax error\n", .code = 500, .params = NULL},
+    {.repr = "501 Format error: Invalid UUID\n", .code = 501, .params = NULL},
+    {.repr = "502 Format error: body too long\n", .code = 502, .params = NULL},
+    {.repr = "503 Format error: name too long\n", .code = 503, .params = NULL},
+    {.repr = "504 Format error: description too long\n", .code = 504, .params = NULL},
+    {.repr = "510 Syntax error: Wrong number of arguments\n", .code = 510, .params = NULL},
+    {.repr = "520 Syntax error: Invalid format\n", .code = 520, .params = NULL},
+    {.repr = "530 Syntax error: Command not found\n", .code = 530, .params = NULL},
+    {.repr = "540 Syntax error: Not implemented\n", .code = 540, .params = NULL},
     {0, 0, 0}
 };
 
 /// \brief Get a retcodes_t structure depending on the code passed as parameter.
 /// \param int The code to be send.
 /// \return A new instance of retcodes_t.
-static inline retcodes_t *get_copy_repcodes_by_code(int code) {
+static inline retcodes_t *create_new_repcode(int code) {
     retcodes_t *retcode = (retcodes_t *) malloc(sizeof(retcodes_t));
 
     if (!retcode)

--- a/server/src/commands/rcodes.h
+++ b/server/src/commands/rcodes.h
@@ -40,6 +40,9 @@ const retcodes_t retcode[] = {
     {0, 0, 0}
 };
 
+/// \brief Get a retcodes_t structure depending on the code passed as parameter.
+/// \param int The code to be send.
+/// \return A new instance of retcodes_t.
 static inline retcodes_t *get_copy_repcodes_by_code(int code) {
     retcodes_t *retcode = (retcodes_t *) malloc(sizeof(retcodes_t));
 

--- a/server/src/commands/rcodes.h
+++ b/server/src/commands/rcodes.h
@@ -1,0 +1,56 @@
+/*
+** EPITECH PROJECT, 2022
+** my_teams
+** File description:
+** rcodes
+*/
+
+#ifndef RCODES_H_
+    #define RCODES_H_
+
+    #include <stdlib.h>
+
+typedef struct retcodes_s {
+    char *repr;
+    int code;
+    char **params;
+} retcodes_t;
+
+const retcodes_t retcode[] = {
+    {.repr = "200 Success\n", .code = 200, .params = 0},
+    {.repr = "201 Successfully connected to existing used: %s\n", .code = 201, .params = 0},
+    {.repr = "202 Successfully connected, new user created with username: %s\n", .code = 202, .params = 0},
+    {.repr = "203 Successfully disconnected as user: %s\n", .code = 203, .params = 0},
+    {.repr = "310 No requested data found, empty relation\n", .code = 310, .params = 0},
+    {.repr = "311 Reqested UUID: %s not found\n", .code = 311, .params = 0},
+    {.repr = "312 Requested username: %s not found\n", .code = 312, .params = 0},
+    {.repr = "320 Invalid action: Data already exist\n", .code = 320, .params = 0},
+    {.repr = "321 Invalid action: Already subscribed to %s\n", .code = 321, .params = 0},
+    {.repr = "322 Invalid action: Not subscribed to %s\n", .code = 322, .params = 0},
+    {.repr = "401 Invalid requested action, please login\n", .code = 400, .params = 0},
+    {.repr = "500 Syntax error\n", .code = 500, .params = 0},
+    {.repr = "501 Format error: Invalid UUID\n", .code = 501, .params = 0},
+    {.repr = "502 Format error: body too long\n", .code = 502, .params = 0},
+    {.repr = "503 Format error: name too long\n", .code = 503, .params = 0},
+    {.repr = "504 Format error: description too long\n", .code = 504, .params = 0},
+    {.repr = "510 Syntax error: Wrong number of arguments\n", .code = 510, .params = 0},
+    {.repr = "520 Syntax error: Invalid format\n", .code = 520, .params = 0},
+    {.repr = "530 Syntax error: Command not found\n", .code = 530, .params = 0},
+    {.repr = "540 Syntax error: Not implemented\n", .code = 540, .params = 0},
+    {0, 0, 0}
+};
+
+static inline retcodes_t *get_copy_repcodes_by_code(int code) {
+    retcodes_t *retcode = (retcodes_t *) malloc(sizeof(retcodes_t));
+
+    if (!retcode)
+        return NULL;
+    for (int i = 0; retcode[i].repr; i++) {
+        if (retcode[i].code == code)
+            return retcode;
+    }
+    free(retcode);
+    return NULL;
+}
+
+#endif /* !RCODES_H_ */


### PR DESCRIPTION
This pull request is linked to the issue #73.
It creates a rcodes.h file which contains all RFC returns codes with a getter function to get them.